### PR TITLE
fix: overflow screen issues on mobile.

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -374,6 +374,9 @@ footer{padding: 40px; text-align: center; line-height: 21px; color: #bfc3c8;}
 }
 
 @media(max-width: 900px){
+  *,*::before,*::after{box-sizing: border-box;}
+  body{overflow-x:hidden;}
+  #main #post_detail{width:100%;}
   #cnblogs_post_body p:first-child img{margin:0;width:100%;}
   #alex-navigator{display: none;}
 }


### PR DESCRIPTION
make sure all elements with `box-sizing: border-box`.  [box-sizing](https://developer.mozilla.org/en-US/docs/Web/CSS/box-sizing)
disable horizontal scroll.
limited post content width.